### PR TITLE
Support lazily decoding pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,10 @@ The `allowNull` option lets you specify whether zero offsets are allowed or shou
 set to `true` by default. The `nullValue` option is related, and lets you override the encoded value that
 represents `null`. By default, the `nullValue` is zero.
 
+The `lazy` option allows lazy decoding of the pointer's value by defining a getter on the parent object.
+This only works when the pointer is contained within a Struct, but can be used to speed up decoding
+quite a bit when not all of the data is needed right away.
+
 ```javascript
 var Address = new r.Struct({
   street: r.String(r.uint8),

--- a/src/Pointer.coffee
+++ b/src/Pointer.coffee
@@ -1,9 +1,12 @@
+utils = require './utils'
+
 class Pointer
   constructor: (@offsetType, @type, @options = {}) ->
     @type = null if @type is 'void'
     @options.type ?= 'local'
     @options.allowNull ?= true
     @options.nullValue ?= 0
+    @options.lazy ?= false
     if @options.relativeTo
       @relativeToGetter = new Function('ctx', "return ctx.#{@options.relativeTo}")
 
@@ -32,10 +35,23 @@ class Pointer
     ptr = offset + relative
 
     if @type?
-      stream.pos = ptr
-      res = @type.decode(stream, ctx)
-      stream.pos = pos
-      return res
+      val = null
+      decodeValue = =>
+        return val if val?
+          
+        pos = stream.pos
+        stream.pos = ptr
+        val = @type.decode(stream, ctx)
+        stream.pos = pos
+        return val
+        
+      # If this is a lazy pointer, define a getter to decode only when needed.
+      # This obviously only works when the pointer is contained by a Struct.
+      if @options.lazy
+        return new utils.PropertyDescriptor
+          get: decodeValue
+        
+      return decodeValue()
     else
       return ptr
 

--- a/src/Pointer.coffee
+++ b/src/Pointer.coffee
@@ -12,7 +12,6 @@ class Pointer
 
   decode: (stream, ctx) ->
     offset = @offsetType.decode(stream)
-    pos = stream.pos
 
     # handle NULL pointers
     if offset is @options.nullValue and @options.allowNull

--- a/src/Struct.coffee
+++ b/src/Struct.coffee
@@ -1,3 +1,5 @@
+utils = require './utils'
+
 class Struct
   constructor: (@fields = {}) ->
 
@@ -26,8 +28,13 @@ class Struct
         val = type.call(res)
       else
         val = type.decode(stream, res)
+        
+      unless val is undefined
+        if val instanceof utils.PropertyDescriptor
+          Object.defineProperty res, key, val
+        else
+          res[key] = val
 
-      res[key] = val unless val is undefined
       res._currentOffset = stream.pos - res._startOffset
 
     return

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -14,3 +14,13 @@ exports.resolveLength = (length, stream, parent) ->
     return length.decode(stream)
 
   return null
+
+class PropertyDescriptor
+  constructor: (opts = {}) ->
+    @enumerable = true
+    @configurable = true
+    
+    for key, val of opts
+      this[key] = val
+
+exports.PropertyDescriptor = PropertyDescriptor

--- a/test/Pointer.coffee
+++ b/test/Pointer.coffee
@@ -1,4 +1,4 @@
-{Pointer, VoidPointer, uint8, DecodeStream, EncodeStream} = require '../'
+{Pointer, VoidPointer, uint8, DecodeStream, EncodeStream, Struct} = require '../'
 should = require('chai').should()
 concat = require 'concat-stream'
 
@@ -40,6 +40,16 @@ describe 'Pointer', ->
       stream = new DecodeStream new Buffer [4]
       pointer = new Pointer uint8, 'void'
       pointer.decode(stream, _startOffset: 0).should.equal 4
+      
+    it 'should support decoding pointers lazily', ->
+      stream = new DecodeStream new Buffer [1, 53]
+      struct = new Struct
+        ptr: new Pointer uint8, uint8, lazy: yes
+        
+      res = struct.decode(stream)
+      Object.getOwnPropertyDescriptor(res, 'ptr').get.should.be.a('function')
+      Object.getOwnPropertyDescriptor(res, 'ptr').enumerable.should.equal(true)
+      res.ptr.should.equal 53
 
   describe 'size', ->
     it 'should add to local pointerSize', ->


### PR DESCRIPTION
Instead of immediately decoding the value pointed to, this allows lazy decoding by defining a getter on the parent object. Obviously it only works when the pointer is contained within a Struct, not an Array or something else. When used, it can speed up decoding quite a bit when not all data is needed right away.