### PR TITLE
Add a LazyArray type

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,25 @@ var struct = new r.Struct({
 var arr = new r.Array(r.uint16, 6, 'bytes');
 ```
 
+### LazyArray
+
+The `LazyArray` type extends from the `Array` type, and is useful for large arrays that you do not need to access sequentially. 
+It avoids decoding the entire array upfront, and instead only decodes and caches individual items as needed. It only works when 
+the elements inside the array have a fixed size.
+
+Instead of returning a JavaScript array, the `LazyArray` type returns a custom object that can be used to access the elements.
+
+```javascript
+var arr = new r.LazyArray(r.uint16, 2048);
+var res = arr.decode(stream);
+
+// get a single element
+var el = res.get(2);
+
+// convert to a normal array (decode all elements)
+var array = res.toArray();
+```
+
 ### Struct
 
 A `Struct` maps to and from JavaScript objects, containing keys of various previously discussed types. Sub structures,

--- a/index.coffee
+++ b/index.coffee
@@ -1,6 +1,7 @@
 exports.EncodeStream    = require './src/EncodeStream'
 exports.DecodeStream    = require './src/DecodeStream'
 exports.Array           = require './src/Array'
+exports.LazyArray       = require './src/LazyArray'
 exports.Bitfield        = require './src/Bitfield'
 exports.Boolean         = require './src/Boolean'
 exports.Buffer          = require './src/Buffer'

--- a/src/Array.coffee
+++ b/src/Array.coffee
@@ -9,7 +9,9 @@ class ArrayT
 
     res = []
     ctx = parent
-    length = utils.resolveLength @length, stream, parent
+    
+    if @length
+      length = utils.resolveLength @length, stream, parent
 
     if @length instanceof NumberT
       # define hidden properties

--- a/src/Array.coffee
+++ b/src/Array.coffee
@@ -10,7 +10,7 @@ class ArrayT
     res = []
     ctx = parent
     
-    if @length
+    if @length?
       length = utils.resolveLength @length, stream, parent
 
     if @length instanceof NumberT

--- a/src/Buffer.coffee
+++ b/src/Buffer.coffee
@@ -7,7 +7,10 @@ class BufferT
     length = utils.resolveLength @length, stream, parent
     return stream.readBuffer(length)
 
-  size: (val) ->
+  size: (val, parent) ->
+    unless val
+      return utils.resolveLength @length, null, parent
+      
     return val.length
 
   encode: (stream, buf, parent) ->

--- a/src/LazyArray.coffee
+++ b/src/LazyArray.coffee
@@ -1,0 +1,58 @@
+ArrayT = require './Array'
+{Number:NumberT} = require './Number'
+utils = require './utils'
+{inspect} = require 'util'
+
+class LazyArrayT extends ArrayT
+  decode: (stream, parent) ->
+    pos = stream.pos
+    length = utils.resolveLength @length, stream, parent
+    
+    if @length instanceof NumberT
+      parent =
+        parent: parent
+        _startOffset: pos
+        _currentOffset: 0
+        _length: length
+    
+    res = new LazyArray @type, length, stream, parent
+    
+    stream.pos += length * @type.size(null, parent)
+    return res
+    
+  size: (val, ctx) ->
+    if val instanceof LazyArray
+      val = val.toArray()
+      
+    super val, ctx
+    
+  encode: (stream, val, ctx) ->
+    if val instanceof LazyArray
+      val = val.toArray()
+      
+    super stream, val, ctx
+
+class LazyArray
+  constructor: (@type, @length, @stream, @ctx) ->
+    @base = @stream.pos
+    @items = []
+    
+  get: (index) ->
+    if index < 0 or index >= @length
+      return undefined
+    
+    unless @items[index]?
+      pos = @stream.pos
+      @stream.pos = @base + @type.size(null, @ctx) * index
+      @items[index] = @type.decode @stream, @ctx
+      @stream.pos = pos
+      
+    return @items[index]
+    
+  toArray: ->
+    @get(i) for i in [0...@length] by 1
+    
+  inspect: ->
+    inspect @toArray()
+
+module.exports = LazyArrayT

--- a/src/Pointer.coffee
+++ b/src/Pointer.coffee
@@ -55,9 +55,6 @@ class Pointer
       return ptr
 
   size: (val, ctx) ->
-    unless val?
-      return @offsetType.size()
-
     parent = ctx
     switch @options.type
       when 'local', 'immediate'
@@ -76,7 +73,9 @@ class Pointer
       type = val.type
       val = val.value
 
-    ctx?.pointerSize += type.size(val, parent)
+    if val and ctx
+      ctx.pointerSize += type.size(val, parent)
+      
     return @offsetType.size()
 
   encode: (stream, val, ctx) ->

--- a/src/String.coffee
+++ b/src/String.coffee
@@ -25,8 +25,12 @@ class StringT
       stream.pos++
 
     return string
-
+    
   size: (val, parent) ->
+    # Use the defined value if no value was given
+    unless val
+      return utils.resolveLength @length, null, parent
+    
     encoding = @encoding
     if typeof encoding is 'function'
       encoding = encoding.call(parent?.val) or 'ascii'

--- a/src/Struct.coffee
+++ b/src/Struct.coffee
@@ -47,7 +47,7 @@ class Struct
 
     size = 0
     for key, type of @fields when type.size?
-      size += type.size(val[key] or 0, ctx)
+      size += type.size(val[key], ctx)
 
     if includePointers
       size += ctx.pointerSize

--- a/src/VersionedStruct.coffee
+++ b/src/VersionedStruct.coffee
@@ -30,6 +30,9 @@ class VersionedStruct extends Struct
     return res
 
   size: (val, parent, includePointers = true) ->
+    unless val
+      throw new Error 'Not a fixed size'
+    
     ctx =
       parent: parent
       val: val
@@ -41,14 +44,14 @@ class VersionedStruct extends Struct
 
     if @versions.header
       for key, type of @versions.header when type.size?
-        size += type.size(val[key] or 0, ctx)
+        size += type.size(val[key], ctx)
 
     fields = @versions[val.version]
     if not fields?
       throw new Error "Unknown version #{val.version}"
 
     for key, type of fields when type.size?
-      size += type.size(val[key] or 0, ctx)
+      size += type.size(val[key], ctx)
 
     if includePointers
       size += ctx.pointerSize
@@ -72,7 +75,7 @@ class VersionedStruct extends Struct
 
     if @versions.header
       for key, type of @versions.header when type.encode?
-        type.encode(stream, val[key] or 0, ctx)
+        type.encode(stream, val[key], ctx)
 
     fields = @versions[val.version]
     for key, type of fields when type.encode?

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -11,6 +11,9 @@ exports.resolveLength = (length, stream, parent) ->
     return parent[length]
 
   if length instanceof NumberT
+    unless stream
+      throw new Error 'Not a fixed size'
+      
     return length.decode(stream)
 
   return null

--- a/src/utils.coffee
+++ b/src/utils.coffee
@@ -2,21 +2,21 @@
 
 exports.resolveLength = (length, stream, parent) ->
   if typeof length is 'number'
-    return length
+    res = length
 
-  if typeof length is 'function'
-    return length.call(parent)
+  else if typeof length is 'function'
+    res = length.call(parent)      
 
-  if parent and typeof length is 'string'
-    return parent[length]
+  else if parent and typeof length is 'string'
+    res = parent[length]
 
-  if length instanceof NumberT
-    unless stream
-      throw new Error 'Not a fixed size'
-      
-    return length.decode(stream)
+  else if stream and length instanceof NumberT
+    res = length.decode(stream)
 
-  return null
+  if isNaN res
+    throw new Error 'Not a fixed size'
+    
+  return res
 
 class PropertyDescriptor
   constructor: (opts = {}) ->

--- a/test/Array.coffee
+++ b/test/Array.coffee
@@ -62,6 +62,10 @@ describe 'Array', ->
     it 'should add size of length field before string', ->
       array = new ArrayT uint8, uint8
       array.size([1, 2, 3, 4]).should.equal 5
+      
+    it 'should use defined length if no value given', ->
+      array = new ArrayT uint8, 10
+      array.size().should.equal 10
 
   describe 'encode', ->
     it 'should encode using array length', (done) ->

--- a/test/Buffer.coffee
+++ b/test/Buffer.coffee
@@ -1,31 +1,48 @@
-{Buffer:BufferT, DecodeStream, EncodeStream} = require '../'
+{Buffer:BufferT, DecodeStream, EncodeStream, uint8} = require '../'
 should = require('chai').should()
 concat = require 'concat-stream'
 
 describe 'Buffer', ->
-  it 'should decode', ->
-    stream = new DecodeStream new Buffer [0xab, 0xff, 0x1f, 0xb6]
-    buf = new BufferT(2)
-    buf.decode(stream).should.deep.equal new Buffer [0xab, 0xff]
-    buf.decode(stream).should.deep.equal new Buffer [0x1f, 0xb6]
+  describe 'decode', ->
+    it 'should decode', ->
+      stream = new DecodeStream new Buffer [0xab, 0xff, 0x1f, 0xb6]
+      buf = new BufferT(2)
+      buf.decode(stream).should.deep.equal new Buffer [0xab, 0xff]
+      buf.decode(stream).should.deep.equal new Buffer [0x1f, 0xb6]
 
-  it 'should decode with parent key length', ->
-    stream = new DecodeStream new Buffer [0xab, 0xff, 0x1f, 0xb6]
-    buf = new BufferT('len')
-    buf.decode(stream, len: 3).should.deep.equal new Buffer [0xab, 0xff, 0x1f]
-    buf.decode(stream, len: 1).should.deep.equal new Buffer [0xb6]
+    it 'should decode with parent key length', ->
+      stream = new DecodeStream new Buffer [0xab, 0xff, 0x1f, 0xb6]
+      buf = new BufferT('len')
+      buf.decode(stream, len: 3).should.deep.equal new Buffer [0xab, 0xff, 0x1f]
+      buf.decode(stream, len: 1).should.deep.equal new Buffer [0xb6]
+      
+  describe 'size', ->
+    it 'should return size', ->
+      buf = new BufferT(2)
+      buf.size(new Buffer [0xab, 0xff]).should.equal 2
 
-  it 'should encode', (done) ->
-    stream = new EncodeStream
-    stream.pipe concat (buf) ->
-      buf.should.deep.equal new Buffer [0xab, 0xff, 0x1f, 0xb6]
-      done()
+    it 'should use defined length if no value given', ->
+      array = new BufferT 10
+      array.size().should.equal 10
 
-    buf = new BufferT(2)
-    buf.encode stream, new Buffer [0xab, 0xff]
-    buf.encode stream, new Buffer [0x1f, 0xb6]
-    stream.end()
+  describe 'encode', ->
+    it 'should encode', (done) ->
+      stream = new EncodeStream
+      stream.pipe concat (buf) ->
+        buf.should.deep.equal new Buffer [0xab, 0xff, 0x1f, 0xb6]
+        done()
 
-  it 'should return size', ->
-    buf = new BufferT(2)
-    buf.size(new Buffer [0xab, 0xff]).should.equal 2
+      buf = new BufferT(2)
+      buf.encode stream, new Buffer [0xab, 0xff]
+      buf.encode stream, new Buffer [0x1f, 0xb6]
+      stream.end()
+
+    it 'should encode length before buffer', (done) ->
+      stream = new EncodeStream
+      stream.pipe concat (buf) ->
+        buf.should.deep.equal new Buffer [2, 0xab, 0xff]
+        done()
+
+      buf = new BufferT(uint8)
+      buf.encode stream, new Buffer [0xab, 0xff]
+      stream.end()

--- a/test/LazyArray.coffee
+++ b/test/LazyArray.coffee
@@ -1,0 +1,65 @@
+{LazyArray, Pointer, uint8, uint16, DecodeStream, EncodeStream} = require '../'
+should = require('chai').should()
+concat = require 'concat-stream'
+
+describe 'LazyArray', ->
+  describe 'decode', ->
+    it 'should decode items lazily', ->
+      stream = new DecodeStream new Buffer [1, 2, 3, 4, 5]
+      array = new LazyArray uint8, 4
+      
+      arr = array.decode(stream)
+      arr.should.not.be.an.instanceof Array
+      arr.should.have.length 4
+      stream.pos.should.equal 4
+      
+      arr.get(0).should.equal 1
+      arr.get(1).should.equal 2
+      arr.get(2).should.equal 3
+      arr.get(3).should.equal 4
+      
+      should.not.exist arr.get(-1)
+      should.not.exist arr.get(5)
+      
+    it 'should be able to convert to an array', ->
+      stream = new DecodeStream new Buffer [1, 2, 3, 4, 5]
+      array = new LazyArray uint8, 4
+      
+      arr = array.decode(stream)
+      arr.toArray().should.deep.equal [1, 2, 3, 4]
+      
+    it 'should have an inspect method', ->
+      stream = new DecodeStream new Buffer [1, 2, 3, 4, 5]
+      array = new LazyArray uint8, 4
+      
+      arr = array.decode(stream)
+      arr.inspect().should.equal '[ 1, 2, 3, 4 ]'
+      
+    it 'should decode length as number before array', ->
+      stream = new DecodeStream new Buffer [4, 1, 2, 3, 4, 5]
+      array = new LazyArray uint8, uint8
+      arr = array.decode(stream)
+      
+      arr.toArray().should.deep.equal [1, 2, 3, 4]
+      
+  describe 'size', ->
+    it 'should work with LazyArrays', ->
+      stream = new DecodeStream new Buffer [1, 2, 3, 4, 5]
+      array = new LazyArray uint8, 4
+      arr = array.decode(stream)
+      
+      array.size(arr).should.equal 4
+      
+  describe 'encode', ->
+    it 'should work with LazyArrays', (done) ->
+      stream = new DecodeStream new Buffer [1, 2, 3, 4, 5]
+      array = new LazyArray uint8, 4
+      arr = array.decode(stream)
+      
+      enc = new EncodeStream
+      enc.pipe concat (buf) ->
+        buf.should.deep.equal new Buffer [1, 2, 3, 4]
+        done()
+      
+      array.encode(enc, arr)
+      enc.end()

--- a/test/Pointer.coffee
+++ b/test/Pointer.coffee
@@ -87,6 +87,10 @@ describe 'Pointer', ->
       ctx = pointerSize: 0
       should.throw ->
         pointer.size(30, ctx).should.equal 1
+        
+    it 'should return a fixed size without a value', ->
+      pointer = new Pointer uint8, uint8
+      pointer.size().should.equal 1
 
   describe 'encode', ->
     it 'should handle null pointers', (done) ->

--- a/test/String.coffee
+++ b/test/String.coffee
@@ -64,7 +64,11 @@ describe 'String', ->
     it 'should take null-byte into account', ->
       string = new StringT null, 'utf8'
       string.size('🍻').should.equal 5
-
+      
+    it 'should use defined length if no value given', ->
+      array = new StringT 10
+      array.size().should.equal 10
+      
   describe 'encode', ->
     it 'should encode using string length', (done) ->
       stream = new EncodeStream

--- a/test/Struct.coffee
+++ b/test/Struct.coffee
@@ -74,7 +74,7 @@ describe 'Struct', ->
         age: uint8
 
       should.throw ->
-        struct.size().should.equal 7
+        struct.size()
       , /not a fixed size/i
       
   describe 'encode', ->

--- a/test/Struct.coffee
+++ b/test/Struct.coffee
@@ -60,7 +60,23 @@ describe 'Struct', ->
         ptr: 'hello'
 
       size.should.equal 14
+      
+    it 'should get the correct size when no value is given', ->
+      struct = new Struct
+        name: new StringT 4
+        age: uint8
 
+      struct.size().should.equal 5
+      
+    it 'should throw when getting non-fixed length size and no value is given', ->
+      struct = new Struct
+        name: new StringT uint8
+        age: uint8
+
+      should.throw ->
+        struct.size().should.equal 7
+      , /not a fixed size/i
+      
   describe 'encode', ->
     it 'should encode objects to buffers', (done) ->
       stream = new EncodeStream

--- a/test/VersionedStruct.coffee
+++ b/test/VersionedStruct.coffee
@@ -226,6 +226,20 @@ describe 'VersionedStruct', ->
         ptr: 'hello'
 
       size.should.equal 15
+    
+    it 'should throw if no value is given', ->
+      struct = new VersionedStruct uint8,
+        0:
+          name: new StringT 4, 'ascii'
+          age: uint8
+        1:
+          name: new StringT 4, 'utf8'
+          age: uint8
+          gender: uint8
+
+      should.throw ->
+        struct.size()
+      , /not a fixed size/i
 
   describe 'encode', ->
     it 'should encode objects to buffers', (done) ->


### PR DESCRIPTION
The LazyArray type is useful for large arrays that you do not need to access sequentially. It avoids decoding the entire array upfront, and instead only decodes and caches individual items as needed.

To make this work, I also had to add support for getting the size from a type without a value. This is needed so the LazyArray can skip over all of the elements in the array. Because of this, it only works when the elements inside the array have a fixed size.